### PR TITLE
Adjust typo in getting started doc

### DIFF
--- a/packages/preset-react-app/docs/getting-started/2.md
+++ b/packages/preset-react-app/docs/getting-started/2.md
@@ -70,7 +70,7 @@ Let's add this commands into some scripts of the ``package.json``
 Now we can use ``npm start`` to start the website/app.
 Website/app should be accessible via [http://localhost:3333](http://localhost:3333).
 
-Enjoy you hello world!
+Enjoy your hello world!
 
 ---
 


### PR DESCRIPTION
From `you` to `your` when referencing Hello World